### PR TITLE
Create bash function for ``mkvirtualenv``

### DIFF
--- a/.functions.sh
+++ b/.functions.sh
@@ -3,6 +3,7 @@
 ## Extra functions available at the command line
 ####
 
+########## Python-specific
 workon() {
     ###
     ## Activate the virtual environment
@@ -14,7 +15,32 @@ workon() {
     source $VENV_LOCATION
 }
 
+####
+## Function to create virtual environments
+## Call format: $ mkvirtualenv <virtual-environment-name> [<python-version>]
+## The first parameter is mandatory and it's the name of the new virtual
+## environment to create.
+## The second, optionally indicates the Python version to use (e.g. "python3.8")
+## The new virtual environment will be created in $WORKON_HOME
+####
+mkvirtualenv() {
+    VIRTUALENV_NAME=${1}
+    if [ -z "$VIRTUALENV_NAME" ]; then
+        echo "No name was provided for the new virtual envionment"
+        return -1
+    fi
 
+    if [ -z "$2" ]; then
+        PYTHON_VERSION=$(which python3);
+    else
+        PYTHON_VERSION=${2}
+    fi
+    echo "Creating environment '${VIRTUALENV_NAME}' with $(${PYTHON_VERSION} --version)"
+
+    ${PYTHON_VERSION} -m venv "${WORKON_HOME}/${VIRTUALENV_NAME}"
+}
+
+########## Git
 gitclean() {
     ####
     ### A git helper function
@@ -28,6 +54,7 @@ gitclean() {
 }
 
 
+## Miscellaneous
 man() {
     ### Colors in man pages!
 	env \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Linux Shell Configuration Files
----------------------------------
+# Unix Shell Configuration Files
+--------------------------------
 
-The list of my configuration files. Each file should be dropped into its
+The list of my configuration files. Each file should be placed into its
 corresponding path.
 
 
@@ -15,6 +15,7 @@ $ make dev-deploy
 ```
 
 ## Extensibility & custom configuration
+
 If there exists a file at ``~/.extra``, this configuration will be loaded after
 all the default values, making the configuration extensible. Here, custom
 extensions, aliases, functions, that aren't going to be tracked or versioned
@@ -24,9 +25,8 @@ This will link the files from the downloaded path to the home directory.
 
 # Dependencies
 
-* A monospace font compatible with the zsh characters: `adobe-source-code-pro-fonts.noarch`
-* Virtualenvwrapper (for Python development): `python-virtualenvwrapper.noarch`
-* Zsh
+* A mono spaced font compatible with the zsh characters (for example ``Source Code Pro``).
+* Optionally, the ``zsh`` shell can be used.
 
 
 ## Vim


### PR DESCRIPTION
Again following up on the deprecation of using the OS package
``virtualenvwrapper`` (doc updated), when instead only the two minimal
functions that are required can be implemented.

**pending validation for merging**